### PR TITLE
Use MyApp for the main app class

### DIFF
--- a/www/app/app.js
+++ b/www/app/app.js
@@ -7,7 +7,7 @@ import {Friends} from './data/data';
   providers: [Friends]
 })
 
-export class TabsPage {
+class MyApp {
   constructor(platform: Platform) {
     this.platform = platform;
     this.initializeApp();


### PR DESCRIPTION
Since we already have a class named TabsPage, let's follow what appears to be the convention with most of the Ionic 2 starter repos and name the main class MyApp.  Also, I noticed that some starter repos export MyApp, and some don't.  Is there a convention?  It seems like it doesn't need to be exported, so I removed the export too.
