### PR TITLE
corrected paths for module loaders and the html templateUrl

### DIFF
--- a/www/app/app.js
+++ b/www/app/app.js
@@ -1,12 +1,12 @@
 import {App, Platform} from 'ionic/ionic';
-import {Page1} from './page1';
-import {Page2} from './page2';
-import {Page3} from './page3';
+import {Page1} from './page1/page1';
+import {Page2} from './page2/page2';
+import {Page3} from './page3/page3';
 import './app.scss';
 
 
 @App({
-  templateUrl: 'app.html'
+  templateUrl: 'app/app.html'
 })
 export class MyApp {
   constructor(platform: Platform) {


### PR DESCRIPTION
when starting from scratch and trying to run `ionic start appName --v2`, the scaffold is created but `ionic serve` fails because the paths are incorrect. 
