### PR TITLE
Fix wrong color overwrite for each platform

### DIFF
--- a/www/app/app.variables.scss
+++ b/www/app/app.variables.scss
@@ -28,3 +28,21 @@ $colors: (
   dark:       #222,
   favorite:   #69BB7B
 );
+
+$colors-md: (
+  primary:    map-get($colors, primary),
+  secondary:  map-get($colors, secondary),
+  danger:     map-get($colors, danger),
+  light:      map-get($colors, light),
+  dark:       map-get($colors, dark),
+  favorite:   map-get($colors, favorite)
+);
+
+$colors-ios: (
+  primary:    map-get($colors, primary),
+  secondary:  map-get($colors, secondary),
+  danger:     map-get($colors, danger),
+  light:      map-get($colors, light),
+  dark:       map-get($colors, dark),
+  favorite:   map-get($colors, favorite)
+);


### PR DESCRIPTION
The ionic alpha.42 separated the colors in variables $colors-md and $colors-ios respectively to android or browse, and ios, $colors alone wasn't overriding colors properly, thus this mapping for each platform, aside letting clear that you can override colors for specific platforms.
